### PR TITLE
POC-6 review and adjustments

### DIFF
--- a/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
+++ b/ethereumj-core/src/main/java/org/ethereum/config/SystemProperties.java
@@ -21,7 +21,7 @@ public class SystemProperties {
 	private static Logger logger = LoggerFactory.getLogger(SystemProperties.class);
 
 	private static int      DEFAULT_TX_APPROVE_TIMEOUT = 10;
-	private static byte     DEFAULT_PROTOCOL_VERSION = 0;
+	private static int      DEFAULT_PROTOCOL_VERSION = 33;
 	private static String   DEFAULT_DISCOVERY_PEER_LIST = "poc-6.ethdev.com:30303";
 	private static String   DEFAULT_ACTIVE_PEER_IP = "poc-6.ethdev.com";
 	private static int      DEFAULT_ACTIVE_PORT = 30303;
@@ -82,9 +82,9 @@ public class SystemProperties {
 		}
 	}
 
-	public byte protocolVersion() {
+	public int protocolVersion() {
 		if (prop.isEmpty()) return DEFAULT_PROTOCOL_VERSION;
-		return Byte.parseByte(prop.getProperty("protocol.version"));
+		return Integer.parseInt(prop.getProperty("protocol.version"));
 	}
 
 	public boolean peerDiscovery() {

--- a/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/BlockchainImpl.java
@@ -4,6 +4,7 @@ import org.ethereum.facade.Blockchain;
 import org.ethereum.facade.Repository;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.manager.WorldManager;
+import org.ethereum.net.BlockQueue;
 import org.ethereum.util.AdvancedDeviceUtils;
 import org.ethereum.vm.*;
 import org.slf4j.Logger;

--- a/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
+++ b/ethereumj-core/src/main/java/org/ethereum/core/Transaction.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.spongycastle.util.BigIntegers;
 
+import java.math.BigInteger;
 import java.security.SignatureException;
 
 /**

--- a/ethereumj-core/src/main/java/org/ethereum/facade/Blockchain.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Blockchain.java
@@ -4,7 +4,7 @@ import java.math.BigInteger;
 import java.util.Map;
 
 import org.ethereum.core.Block;
-import org.ethereum.core.BlockQueue;
+import org.ethereum.net.BlockQueue;
 import org.ethereum.core.Genesis;
 
 public interface Blockchain  {

--- a/ethereumj-core/src/main/java/org/ethereum/facade/Ethereum.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/Ethereum.java
@@ -2,10 +2,9 @@ package org.ethereum.facade;
 
 import org.ethereum.core.Transaction;
 import org.ethereum.core.Wallet;
-import org.ethereum.facade.Repository;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.client.PeerClient;
-import org.ethereum.net.client.Peer;
+import org.ethereum.net.peerdiscovery.PeerData;
 
 import java.net.InetAddress;
 import java.util.Set;
@@ -25,7 +24,7 @@ public interface Ethereum {
      * @param excludePeer - peer to exclude
      * @return online peer if available otherwise null
      */
-    public Peer findOnlinePeer(Peer excludePeer) ;
+    public PeerData findOnlinePeer(PeerData excludePeer) ;
 
     /**
      * Find an online peer but not from excluded list
@@ -33,12 +32,12 @@ public interface Ethereum {
      * @param excludePeerSet - peers to exclude
      * @return online peer if available otherwise null
      */
-    public Peer findOnlinePeer(Set<Peer> excludePeerSet) ;
+    public PeerData findOnlinePeer(Set<PeerData> excludePeerSet) ;
 
     /**
      * @return online peer if available
      */
-    public Peer findOnlinePeer();
+    public PeerData findOnlinePeer();
 
 
     /**
@@ -46,7 +45,7 @@ public interface Ethereum {
      *
      * @return online peer.
      */
-    public Peer waitForOnlinePeer();
+    public PeerData waitForOnlinePeer();
 
     /*
      *
@@ -59,7 +58,7 @@ public interface Ethereum {
      *    }
      *
      */
-    public Set<Peer> getPeers();
+    public Set<PeerData> getPeers();
 
     public void startPeerDiscovery();
     public void stopPeerDiscovery();

--- a/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
+++ b/ethereumj-core/src/main/java/org/ethereum/facade/EthereumImpl.java
@@ -10,7 +10,7 @@ import org.ethereum.core.Wallet;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.manager.WorldManager;
 import org.ethereum.net.client.PeerClient;
-import org.ethereum.net.client.Peer;
+import org.ethereum.net.peerdiscovery.PeerData;
 import org.ethereum.net.submit.TransactionExecutor;
 import org.ethereum.net.submit.TransactionTask;
 import org.slf4j.Logger;
@@ -37,20 +37,20 @@ public class EthereumImpl implements Ethereum {
      * @return online peer
      */
     @Override
-    public Peer findOnlinePeer(Peer peer) {
-        Set<Peer> excludePeers = new HashSet<>();
+    public PeerData findOnlinePeer(PeerData peer) {
+        Set<PeerData> excludePeers = new HashSet<>();
         excludePeers.add(peer);
         return findOnlinePeer(excludePeers);
     }
 
     @Override
-    public Peer findOnlinePeer() {
-        Set<Peer> excludePeers = new HashSet<>();
+    public PeerData findOnlinePeer() {
+        Set<PeerData> excludePeers = new HashSet<>();
         return findOnlinePeer(excludePeers);
     }
 
     @Override
-    public Peer findOnlinePeer(Set<Peer> excludePeers)  {
+    public PeerData findOnlinePeer(Set<PeerData> excludePeers)  {
         logger.info("Looking for online peers...");
 
         final EthereumListener listener = WorldManager.getInstance().getListener();
@@ -60,9 +60,9 @@ public class EthereumImpl implements Ethereum {
 
         WorldManager.getInstance().startPeerDiscovery();
 
-        final Set<Peer> peers = WorldManager.getInstance().getPeerDiscovery().getPeers();
+        final Set<PeerData> peers = WorldManager.getInstance().getPeerDiscovery().getPeers();
         synchronized (peers) {
-            for (Peer peer : peers) { // it blocks until a peer is available.
+            for (PeerData peer : peers) { // it blocks until a peer is available.
 				if (peer.isOnline() && !excludePeers.contains(peer)) {
                     logger.info("Found peer: {}", peer.toString());
                     if (listener != null)
@@ -75,8 +75,8 @@ public class EthereumImpl implements Ethereum {
     }
 
     @Override
-    public Peer waitForOnlinePeer() {
-        Peer peer = null;
+    public PeerData waitForOnlinePeer() {
+        PeerData peer = null;
 		while (peer == null) {
 			try {
 				Thread.sleep(100);
@@ -89,7 +89,7 @@ public class EthereumImpl implements Ethereum {
     }
 
     @Override
-    public Set<Peer> getPeers() {
+    public Set<PeerData> getPeers() {
         return WorldManager.getInstance().getPeerDiscovery().getPeers();
     }
 

--- a/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
+++ b/ethereumj-core/src/main/java/org/ethereum/manager/WorldManager.java
@@ -13,7 +13,7 @@ import org.ethereum.facade.Blockchain;
 import org.ethereum.facade.Repository;
 import org.ethereum.listener.EthereumListener;
 import org.ethereum.net.client.PeerClient;
-import org.ethereum.net.client.PeerDiscovery;
+import org.ethereum.net.peerdiscovery.PeerDiscovery;
 
 /**
  * WorldManager is a singleton containing references to different parts of the system.
@@ -81,7 +81,7 @@ public class WorldManager {
         if (peerDiscovery.isStarted())
             peerDiscovery.stop();
     }
-    
+
     public PeerDiscovery getPeerDiscovery() {
     	return peerDiscovery;
     }

--- a/ethereumj-core/src/main/java/org/ethereum/net/BlockQueue.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/BlockQueue.java
@@ -1,8 +1,9 @@
-package org.ethereum.core;
+package org.ethereum.net;
 
 import static org.ethereum.config.SystemProperties.CONFIG;
 
 import org.ethereum.config.SystemProperties;
+import org.ethereum.core.Block;
 import org.ethereum.manager.WorldManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ethereumj-core/src/main/java/org/ethereum/net/MessageQueue.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/MessageQueue.java
@@ -26,12 +26,12 @@ import java.util.concurrent.ConcurrentLinkedQueue;
  */
 public class MessageQueue {
 
-	private Logger logger = LoggerFactory.getLogger("wire");
+	private Logger logger = LoggerFactory.getLogger("net");
 
 	private Queue<MessageRoundtrip> messageQueue = new ConcurrentLinkedQueue<>();
 	private PeerListener listener;
 	private ChannelHandlerContext ctx = null;
-	private final Timer timer = new Timer();
+	private final Timer timer = new Timer("MessageQueue");
 
 	public MessageQueue(ChannelHandlerContext ctx, PeerListener listener) {
 		this.ctx = ctx;
@@ -95,4 +95,8 @@ public class MessageQueue {
 			}
 		}
 	}
+
+    public void close(){
+        timer.purge();
+    }
 }

--- a/ethereumj-core/src/main/java/org/ethereum/net/client/PeerClient.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/client/PeerClient.java
@@ -8,9 +8,10 @@ import io.netty.handler.timeout.ReadTimeoutHandler;
 
 import org.ethereum.manager.WorldManager;
 import org.ethereum.net.PeerListener;
+import org.ethereum.net.handler.MessageDecoder;
+import org.ethereum.net.handler.MessageEncoder;
 import org.ethereum.net.handler.P2pHandler;
-import org.ethereum.net.handler.PacketDecoder;
-import org.ethereum.net.handler.PacketEncoder;
+import org.ethereum.net.peerdiscovery.PeerData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -30,7 +31,13 @@ public class PeerClient {
     private PeerListener peerListener;
     private P2pHandler p2pHandler;
 
+    private boolean peerDiscoveryMode = false;
+
     public PeerClient() {
+    }
+
+    public PeerClient(boolean peerDiscoveryMode){
+        this.peerDiscoveryMode = peerDiscoveryMode;
     }
 
     public PeerClient(PeerListener peerListener) {
@@ -44,7 +51,10 @@ public class PeerClient {
         if (peerListener != null)
         	peerListener.console("Connecting to: " + host + ":" + port);
 
-        p2pHandler = new P2pHandler(peerListener);
+        if (peerDiscoveryMode)
+            p2pHandler = new P2pHandler(peerDiscoveryMode);
+        else
+            p2pHandler = new P2pHandler(peerListener);
         
         try {
             Bootstrap b = new Bootstrap();
@@ -61,8 +71,8 @@ public class PeerClient {
                 public void initChannel(NioSocketChannel ch) throws Exception {
 					ch.pipeline().addLast("readTimeoutHandler",
 							new ReadTimeoutHandler(CONFIG.peerChannelReadTimeout(), TimeUnit.SECONDS));
-					ch.pipeline().addLast(new PacketEncoder());
-					ch.pipeline().addLast(new PacketDecoder());
+					ch.pipeline().addLast(new MessageEncoder());
+					ch.pipeline().addLast(new MessageDecoder());
 					ch.pipeline().addLast(p2pHandler);
 
                     // limit the size of receiving buffer to 1024
@@ -86,10 +96,10 @@ public class PeerClient {
 
         	p2pHandler.killTimers();
 
-            final Set<Peer> peers =  WorldManager.getInstance().getPeerDiscovery().getPeers();
+            final Set<PeerData> peers =  WorldManager.getInstance().getPeerDiscovery().getPeers();
 
 			synchronized (peers) {
-				for (Peer peer : peers) {
+				for (PeerData peer : peers) {
 					if (host.equals(peer.getAddress().getHostAddress())
 							&& port == peer.getPort())
 						peer.setOnline(false);

--- a/ethereumj-core/src/main/java/org/ethereum/net/handler/EthHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/handler/EthHandler.java
@@ -220,7 +220,7 @@ public class EthHandler extends SimpleChannelInboundHandler<EthMessage> {
 	}
 
     private void sendStatus() {
-    	byte protocolVersion = 33, networkId = 0;
+    	byte protocolVersion = CONFIG.protocolVersion(), networkId = 0;
     	BigInteger totalDifficulty = this.blockchain.getTotalDifficulty();
 		byte[] bestHash = this.blockchain.getLatestBlockHash();
 		StatusMessage msg = new StatusMessage(protocolVersion, networkId,

--- a/ethereumj-core/src/main/java/org/ethereum/net/handler/EthHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/handler/EthHandler.java
@@ -17,7 +17,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 
 import org.ethereum.core.Block;
-import org.ethereum.core.BlockQueue;
+import org.ethereum.net.BlockQueue;
 import org.ethereum.core.Transaction;
 import org.ethereum.facade.Blockchain;
 import org.ethereum.manager.WorldManager;
@@ -220,7 +220,7 @@ public class EthHandler extends SimpleChannelInboundHandler<EthMessage> {
 	}
 
     private void sendStatus() {
-    	byte protocolVersion = CONFIG.protocolVersion(), networkId = 0;
+    	byte protocolVersion = 33, networkId = 0;
     	BigInteger totalDifficulty = this.blockchain.getTotalDifficulty();
 		byte[] bestHash = this.blockchain.getLatestBlockHash();
 		StatusMessage msg = new StatusMessage(protocolVersion, networkId,

--- a/ethereumj-core/src/main/java/org/ethereum/net/handler/MessageDecoder.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/handler/MessageDecoder.java
@@ -16,7 +16,7 @@ import java.util.List;
 /**
  * The PacketDecoder parses every valid Ethereum packet to a Message object
  */
-public class PacketDecoder extends ByteToMessageDecoder {
+public class MessageDecoder extends ByteToMessageDecoder {
 
 	private Logger logger = LoggerFactory.getLogger("wire");
 
@@ -43,6 +43,7 @@ public class PacketDecoder extends ByteToMessageDecoder {
 			logger.info("From: \t{} \tRecv: \t{}", ctx.channel().remoteAddress(), msg);
 
 		out.add(msg);
+        in.markReaderIndex();
     }
 	
 	private boolean isValidEthereumPacket(ByteBuf in) {
@@ -64,7 +65,7 @@ public class PacketDecoder extends ByteToMessageDecoder {
 			logger.error("Abandon garbage, wrong sync token: [{}]", syncToken);
 		}
 
-		// Don't have the full packet yet
+		// Don't have the full message yet
         long msgSize = in.getInt(in.readerIndex());
 		if (msgSize > in.readableBytes()) {
 			logger.trace("msg decode: magicBytes: [{}], readBytes: [{}] / msgSize: [{}] ",
@@ -72,6 +73,7 @@ public class PacketDecoder extends ByteToMessageDecoder {
 			in.resetReaderIndex();
 			return false;
 		}
+
 		logger.trace("Message fully constructed: readBytes: [{}] / msgSize: [{}]", in.readableBytes(), msgSize);
 		return true;
 	}

--- a/ethereumj-core/src/main/java/org/ethereum/net/handler/MessageEncoder.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/handler/MessageEncoder.java
@@ -15,7 +15,7 @@ import org.spongycastle.util.encoders.Hex;
 /**
  * The PacketEncoder encodes the message and adds a sync token to every packet.
  */
-public class PacketEncoder extends MessageToByteEncoder<Message> {
+public class MessageEncoder extends MessageToByteEncoder<Message> {
 
 	private Logger logger = LoggerFactory.getLogger("wire");
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/handler/P2pHandler.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/handler/P2pHandler.java
@@ -129,7 +129,7 @@ public class P2pHandler extends SimpleChannelInboundHandler<P2pMessage> {
     }
         
     private void processPeers(ChannelHandlerContext ctx, PeersMessage peersMessage) {
-//        WorldManager.getInstance().getPeerDiscovery().addPeers(peersMessage.getPeers());
+        WorldManager.getInstance().getPeerDiscovery().addPeers(peersMessage.getPeers());
 	}
 
     private void sendPeers() {

--- a/ethereumj-core/src/main/java/org/ethereum/net/message/HelloMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/message/HelloMessage.java
@@ -80,7 +80,7 @@ public class HelloMessage extends P2pMessage {
 		byte[] clientId = RLP.encodeString(this.clientId);
 		byte[][] capabilities = new byte[this.capabilities.size()][];
 		for (int i = 0; i < this.capabilities.size(); i++) {
-			capabilities[i] = RLP.encodeElement(this.capabilities.get(i).getBytes());
+			capabilities[i] = RLP.encode(this.capabilities.get(i).getBytes());
 		}
 		byte[] capabilityList = RLP.encodeList(capabilities);
 		byte[] peerPort = RLP.encodeInt(this.listenPort);

--- a/ethereumj-core/src/main/java/org/ethereum/net/message/HelloMessage.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/message/HelloMessage.java
@@ -80,7 +80,7 @@ public class HelloMessage extends P2pMessage {
 		byte[] clientId = RLP.encodeString(this.clientId);
 		byte[][] capabilities = new byte[this.capabilities.size()][];
 		for (int i = 0; i < this.capabilities.size(); i++) {
-			capabilities[i] = RLP.encode(this.capabilities.get(i).getBytes());
+			capabilities[i] = RLP.encodeElement(this.capabilities.get(i).getBytes());
 		}
 		byte[] capabilityList = RLP.encodeList(capabilities);
 		byte[] peerPort = RLP.encodeInt(this.listenPort);

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerData.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerData.java
@@ -1,4 +1,4 @@
-package org.ethereum.net.client;
+package org.ethereum.net.peerdiscovery;
 
 import org.ethereum.util.RLP;
 import org.spongycastle.util.encoders.Hex;
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * This class models a peer in the network
  */
-public class Peer {
+public class PeerData {
 
 	private InetAddress address;
 	private int port;
@@ -21,7 +21,7 @@ public class Peer {
 	private transient boolean isOnline = false;
 	private transient long lastCheckTime = 0;
 
-	public Peer(InetAddress ip, int port, String peerId) {
+	public PeerData(InetAddress ip, int port, String peerId) {
 		this.address = ip;
 		this.port = port;
 		this.peerId = peerId;
@@ -84,7 +84,7 @@ public class Peer {
 	@Override
 	public boolean equals(Object obj) {
 		if (obj == null) return false;
-		Peer peerData = (Peer) obj;
+		PeerData peerData = (PeerData) obj;
 		return peerData.peerId.equals(this.peerId)
 				|| this.getAddress().equals(peerData.getAddress());
 	}

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerMonitorThread.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/PeerMonitorThread.java
@@ -1,4 +1,4 @@
-package org.ethereum.net.client;
+package org.ethereum.net.peerdiscovery;
 
 import java.util.concurrent.ThreadPoolExecutor;
 

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/RejectionLogger.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/RejectionLogger.java
@@ -1,4 +1,4 @@
-package org.ethereum.net.client;
+package org.ethereum.net.peerdiscovery;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/WorkerThread.java
+++ b/ethereumj-core/src/main/java/org/ethereum/net/peerdiscovery/WorkerThread.java
@@ -1,5 +1,7 @@
-package org.ethereum.net.client;
+package org.ethereum.net.peerdiscovery;
 
+import org.ethereum.net.client.PeerClient;
+import org.ethereum.net.peerdiscovery.PeerData;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -13,11 +15,11 @@ public class WorkerThread implements Runnable {
 
 	private final static Logger logger = LoggerFactory.getLogger("peerdiscovery");
 
-	private Peer peer;
+	private PeerData peer;
 	private PeerClient clientPeer;
 	private ThreadPoolExecutor poolExecutor;
 
-	public WorkerThread(Peer peer, ThreadPoolExecutor poolExecutor) {
+	public WorkerThread(PeerData peer, ThreadPoolExecutor poolExecutor) {
 		this.peer = peer;
 		this.poolExecutor = poolExecutor;
 	}
@@ -34,7 +36,7 @@ public class WorkerThread implements Runnable {
 	private void processCommand() {
 
 		try {
-			clientPeer = new PeerClient();
+			clientPeer = new PeerClient(true);
 			clientPeer.connect(peer.getAddress().getHostAddress(), peer.getPort());
 			peer.setOnline(true);
 		} catch (Throwable e) {
@@ -46,6 +48,7 @@ public class WorkerThread implements Runnable {
 			logger.info("Peer: " + peer.toString() + " is "
 					+ (peer.isOnline() ? "online" : "offline"));
 			peer.setLastCheckTime(System.currentTimeMillis());
+
 		}
 	}
 

--- a/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
+++ b/ethereumj-core/src/main/java/org/ethereum/util/Utils.java
@@ -116,8 +116,12 @@ public class Utils {
     }
 
 	public static StringBuffer getHashlistShort(List<byte[]> blockHashes) {
-		StringBuffer sb = new StringBuffer();
-		String firstHash = Hex.toHexString(blockHashes.get(0));
+
+        StringBuffer sb = new StringBuffer();
+
+        if (blockHashes.isEmpty()) return sb.append("[]");
+
+        String firstHash = Hex.toHexString(blockHashes.get(0));
 		String lastHash = Hex.toHexString(blockHashes.get(blockHashes.size()-1));
 		return sb.append(" ").append(firstHash).append("...").append(lastHash);
 	}

--- a/ethereumj-core/src/main/resources/log4j.properties
+++ b/ethereumj-core/src/main/resources/log4j.properties
@@ -7,7 +7,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.Target=System.out
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss} [%c{1}]  %m%n
-log4j.appender.stdout.Threshold=DEBUG
+log4j.appender.stdout.Threshold=TRACE
 
 # Direct log messages to stdout
 log4j.appender.DUMP=org.apache.log4j.ConsoleAppender
@@ -22,6 +22,7 @@ log4j.appender.file.RollingPolicy.FileNamePattern=./logs/ethereum_%d{yyyy-MM-dd}
 
 # filter noisy classes
 log4j.logger.block = ERROR
+log4j.logger.blockqueue = ERROR
 log4j.logger.wallet = ERROR
 log4j.logger.net = ERROR
 log4j.logger.db = ERROR

--- a/ethereumj-core/src/main/resources/system.properties
+++ b/ethereumj-core/src/main/resources/system.properties
@@ -9,7 +9,8 @@ peer.discovery.ip.list = poc-6.ethdev.com:30303,\
                         54.204.10.41:30303
                         
 # Peer Server Zero (poc-6.ethdev.com)
-peer.active.ip = 207.12.89.101
+peer.active.ip = 185.43.109.23
+
 peer.active.port = 30303
 
 # ZeroGox
@@ -48,7 +49,7 @@ peer.discovery = true
 # number of workers that
 # tastes the peers for being
 # online [1..10]
-peer.discovery.workers = 15
+peer.discovery.workers = 10
 
 # connection timeout for trying to
 # connect to a peer [seconds]

--- a/ethereumj-studio/pom.xml
+++ b/ethereumj-studio/pom.xml
@@ -4,7 +4,7 @@
 	<groupId>org.ethereum</groupId>
 	<artifactId>ethereumj-studio</artifactId>
 	<packaging>jar</packaging>
-	<version>0.6.0</version>
+	<version>0.6.1</version>
 	<name>EthereumJ Studio</name>
 	<url>http://www.ethereumj.org</url>
 

--- a/ethereumj-studio/src/main/java/org/ethereum/gui/PeersTableModel.java
+++ b/ethereumj-studio/src/main/java/org/ethereum/gui/PeersTableModel.java
@@ -10,7 +10,7 @@ import javax.swing.table.AbstractTableModel;
 
 
 import org.ethereum.geo.IpGeoDB;
-import org.ethereum.net.client.Peer;
+import org.ethereum.net.peerdiscovery.PeerData;
 import org.ethereum.util.Utils;
 
 import com.maxmind.geoip.Location;
@@ -110,11 +110,11 @@ public class PeersTableModel extends AbstractTableModel {
         synchronized (peerInfoList) {
             peerInfoList.clear();
 
-            final Set<Peer> peers = UIEthereumManager.ethereum.getPeers();
+            final Set<PeerData> peers = UIEthereumManager.ethereum.getPeers();
 
             synchronized (peers){
 
-                for (Peer peer : peers) {
+                for (PeerData peer : peers) {
                     InetAddress addr = peer.getAddress();
                     Location cr = IpGeoDB.getLocationForIp(addr);
                     peerInfoList.add(new PeerInfo(cr, addr, peer.isOnline(), peer.getLastCheckTime()));

--- a/ethereumj-studio/src/main/resources/log4j.properties
+++ b/ethereumj-studio/src/main/resources/log4j.properties
@@ -36,7 +36,6 @@ log4j.logger.trie = ERROR
 log4j.logger.state = INFO
 log4j.logger.repository = INFO
 log4j.logger.blockchain = INFO
-log4j.logger.blockqueue = ERROR
 log4j.logger.txs = ERROR
 log4j.logger.ui = ERROR
 log4j.logger.gas = ERROR

--- a/ethereumj-studio/src/main/resources/system.properties
+++ b/ethereumj-studio/src/main/resources/system.properties
@@ -9,7 +9,7 @@ peer.discovery.ip.list = poc-6.ethdev.com:30303,\
                         54.204.10.41:30303
                         
 # Peer Server Zero (poc-6.ethdev.com)
-peer.active.ip = 207.12.89.101
+peer.active.ip = 185.43.109.23
 peer.active.port = 30303
 
 # ZeroGox
@@ -43,12 +43,12 @@ protocol.version = 33
 # the peer window will show
 # only what retrieved by active
 # peer [true/false]
-peer.discovery = true
+peer.discovery = false
 
 # number of workers that
 # tastes the peers for being
 # online [1..10]
-peer.discovery.workers = 15
+peer.discovery.workers = 10
 
 # connection timeout for trying to
 # connect to a peer [seconds]


### PR DESCRIPTION
1. BlockQueue moved back to net - because it's a network buffer 
2. PeerData - I call it like that because it's a value object for Peer object I expect usually to have 
                      connect() abilities 
3. PeerDiscovery moved back to autonomous utility , the intention of it is to crawl the network, if we 
   want to connect to more than one peer as a single node we should implement it differently: 
   maybe as active peer and list of passive peers 
4. Messaage/Packet encoder/decoder - packet it's terminology of the wire message it's terminology of the protocol, so message is combined from several packets then it's message encoder/decoder (from wire to protocol level)
5.  in.markReaderIndex(); --> look for that one in the changes to see how the loop bug from yesterday was fixed.
6. I think I did some more bug fixing but don't remember the line so if you have more questions go on 
